### PR TITLE
Update to v2.7.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ catkin_python_setup() # Creates python2.7/dist-packages folder.
 
 ExternalProject_Add(libsbp
   GIT_REPOSITORY https://github.com/swift-nav/libsbp.git
-  GIT_TAG v2.6.5
+  GIT_TAG v2.7.4
   UPDATE_COMMAND git submodule update --init &&
                   cp -r ./generator/sbpg ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION}
   SOURCE_SUBDIR ./c/

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>libsbp_catkin</name>
-  <version>2.6.5</version>
+  <version>2.7.4</version>
   <description>Catkin wrapper for libsbp.</description>
   <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>
 


### PR DESCRIPTION
Reason for this PR:
- allow firmware upgrade for piksi which enables _heading forwarding_
- related to: https://github.com/ethz-asl/ethz_piksi_ros/pull/204